### PR TITLE
Update doc site

### DIFF
--- a/about.md
+++ b/about.md
@@ -23,7 +23,7 @@ In the end, log4j provides a very good abstraction over `console` that solves th
 ## <a id="differences-with-log4j"></a>Differences with log4j
 While Woodman attempts to follow Apache Log4j 2 as closely as possible, it does not implement all its features. In particular, compared to Apache Log4j 2, Woodman comes with: 
 
-- a restricted number of [Appenders](http://logging.apache.org/log4j/2.x/manual/filters.html)
+- a restricted number of [Appenders](http://logging.apache.org/log4j/2.x/manual/appenders.html)
 - a restricted number of [Layouts](http://logging.apache.org/log4j/2.x/manual/layouts.html)
 - a restricted number of [Filters](http://logging.apache.org/log4j/2.x/manual/filters.html)
 - no support for Appender Reference Filters (fourth type in [Filters](http://logging.apache.org/log4j/2.x/manual/filters.html))

--- a/contribute.md
+++ b/contribute.md
@@ -13,7 +13,7 @@ Woodman's [GitHub repository](https://github.com/joshfire/woodman) is organized 
 - The `lib/` folder contains the actual source code of Woodman.
 - The `precompile/` folder contains the precompiler library and command-line interface.
 - The `test/` folder contains unit tests.
-- The `grunt.js` file is a Grunt 0.3 compatible make file that runs the different instructions needed to build Woodman and updates the `dist/` folder accordingly.
+- The `Gruntfile.js` file is a [Grunt](http://gruntjs.com) make file that runs the different instructions needed to build Woodman and update the `dist/` folder accordingly.
 
 To start developing for Woodman, clone the repository and run `npm install` to install the different libraries needed to build Woodman, precompile and/or run tests.
 

--- a/index.md
+++ b/index.md
@@ -12,6 +12,6 @@ Woodman features:
 - **filters** to disable messages based on something else than their level or origin.
 - a **removal tool** that drops all traces of Woodman from your code to create a shipping version of your app without logs. With Woodman, no more `console.log` in your production code!
 
-What now? If that all sounds clear and great, [get started](getstarted.html) then check the [Woodman configuration](config.html) section. If you're ready to dig into the code to fix a bug or implement a new Appender, Layout or Filter, take a look at the [Development](contribute.html) section. Last but not least, if you cannot help but wonder why Woodman exists at all, what it brings on top of the usual `console` and how it relates to other similar projects, check the [About](about.html) section.
+What now? If that all sounds clear and great, [get started](getstarted.html) then check the [configure](config.html) section. If you're ready to dig into the code to fix a bug or implement a new Appender, Layout or Filter, take a look at the [Contribute](contribute.html) section. Last but not least, if you cannot help but wonder why Woodman exists at all, what it brings on top of the usual `console` and how it relates to other similar projects, check the [About](about.html) section.
 
 Wherever applicable, Woodman follows the architecture, terminology and API of the [Apache Log4j 2](http://logging.apache.org/log4j/2.x/) project.


### PR DESCRIPTION
A couple of documentation updates / fixes that I noticed while working with Woodman lately.
- Update log4j appenders link on **about**
- Update the `Gruntfile.js` link on **about**
- Update the section names in the lower portion of the **index** page
